### PR TITLE
isolate enumerize onto their own lines

### DIFF
--- a/app/models/permit.rb
+++ b/app/models/permit.rb
@@ -4,6 +4,11 @@ class Permit < ActiveRecord::Base
 
   extend Enumerize
 
-  enumerize :sec1_q6, :sec1_q8, :sec1_q9, :sec1_q10, :sec1_q12, :sec1_q13, in: [:yes, :no, :na]
+  enumerize :sec1_q6, in: [:yes, :no, :na]
+  enumerize :sec1_q8, in: [:yes, :no, :na]
+  enumerize :sec1_q9, in: [:yes, :no, :na]
+  enumerize :sec1_q10, in: [:yes, :no, :na]
+  enumerize :sec1_q12, in: [:yes, :no, :na]
+  enumerize :sec1_q13, in: [:yes, :no, :na]
   enumerize :status, in: [:draft, :open, :work_completed, :ready_to_inspect, :not_approved, :in_dispute, :closed]
 end


### PR DESCRIPTION
Broke up the multiple enumerize line in the permit model to single enumerize lines
